### PR TITLE
Fixed editing labels when the top of the modeler is not the top of the viewport

### DIFF
--- a/modeler/lib/features/label-editing/LabelEditingProvider.js
+++ b/modeler/lib/features/label-editing/LabelEditingProvider.js
@@ -30,7 +30,7 @@ export default function LabelEditingProvider(
   function decideIfTitelOrAttributesClicked(event) {
     var zoom = canvas.zoom();
     var titel_attribute_divider_y_coordinate = (event.element.y + 30 - canvas._cachedViewbox.y) * zoom;
-    var click_y_coordinate = event.originalEvent.y;
+    var click_y_coordinate = event.originalEvent.offsetY;
     if (click_y_coordinate >= titel_attribute_divider_y_coordinate) {
       event.element.businessObject.labelAttribute = 'attributeValues';
     } else {


### PR DESCRIPTION
Hi @timKraeuter,

Great work on the object-diagram-modeler! During a few test-runs, I discovered that I couldn't edit the title of an element. This was due to the modeler not being at the top of my page. It currently takes the `y` attribute from the dblclick's `MouseEvent`, which is relative to the viewport. However, I think it is better to use `offsetY` ([docs](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/offsetY)), which is relative to "the padding edge of the target node." Theferofe, it works when embedding the modeler inside a webapp.