### PR TITLE
Add Playwright e2e tests for starter app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,37 @@ jobs:
         run: |
           npm i
           npm run all
+
+  e2e:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install starter dependencies
+        working-directory: ./starter
+        run: npm i
+
+      - name: Build starter
+        working-directory: ./starter
+        run: npm run build
+
+      - name: Run Playwright tests
+        working-directory: ./starter
+        run: npx playwright test
+        env:
+          HOME: /root
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: starter/playwright-report/
+          retention-days: 30

--- a/starter/.gitignore
+++ b/starter/.gitignore
@@ -1,2 +1,6 @@
 public
 node_modules
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/starter/e2e/fixtures/sampleBoard.xml
+++ b/starter/e2e/fixtures/sampleBoard.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<od:definitions xmlns:od="http://tk/schema/od" xmlns:odDi="http://tk/schema/odDi"
+                xmlns:dc="http://www.omg.org/spec/DD/20100524/DC">
+    <od:odBoard id="Board_debug">
+        <od:link name="components" id="Link_Object_2669_to_Object_2837_type_components" type="components"
+                 sourceRef="Object_2669" targetRef="Object_2837"/>
+        <od:link name="components" id="Link_Object_2669_to_Object_2838_type_components" type="components"
+                 sourceRef="Object_2669" targetRef="Object_2838"/>
+        <od:link name="components" id="Link_Object_2669_to_Object_2839_type_components" type="components"
+                 sourceRef="Object_2669" targetRef="Object_2839"/>
+        <od:link name="components" id="Link_Object_2669_to_Object_2840_type_components" type="components"
+                 sourceRef="Object_2669" targetRef="Object_2840"/>
+        <od:object name="folding_wall_table:Product" id="Object_2669"
+                   attributeValues="cost=5&#10;name=&#34;Folding wall table&#34;">
+            <od:links>Link_Object_2669_to_Object_2837_type_components</od:links>
+            <od:links>Link_Object_2669_to_Object_2838_type_components</od:links>
+            <od:links>Link_Object_2669_to_Object_2839_type_components</od:links>
+            <od:links>Link_Object_2669_to_Object_2840_type_components</od:links>
+        </od:object>
+        <od:object name="0:QuantifiedComponent" id="Object_2837" attributeValues="quantity=4"/>
+        <od:object name="1:QuantifiedComponent" id="Object_2838" attributeValues="quantity=10"/>
+        <od:object name="2:QuantifiedComponent" id="Object_2839" attributeValues="quantity=1"/>
+        <od:object name="3:QuantifiedComponent" id="Object_2840" attributeValues="quantity=26"/>
+    </od:odBoard>
+    <odDi:odRootBoard id="RootBoard_debug">
+        <odDi:odPlane id="Plane_debug" boardElement="Board_debug">
+            <odDi:link id="Link_Object_2669_to_Object_2837_type_components_di"
+                       boardElement="Link_Object_2669_to_Object_2837_type_components">
+                <odDi:waypoint x="566.1" y="198.60000000000002"/>
+                <odDi:waypoint x="566.1" y="233.60000000000002"/>
+                <odDi:waypoint x="652.5" y="233.60000000000002"/>
+                <odDi:waypoint x="652.5" y="296.6"/>
+                <odDi:odLabel>
+                    <dc:Bounds x="560" y="240" width="82" height="18"/>
+                </odDi:odLabel>
+            </odDi:link>
+            <odDi:link id="Link_Object_2669_to_Object_2838_type_components_di"
+                       boardElement="Link_Object_2669_to_Object_2838_type_components">
+                <odDi:waypoint x="610.3" y="198.60000000000002"/>
+                <odDi:waypoint x="610.3" y="223.60000000000002"/>
+                <odDi:waypoint x="869.5" y="223.60000000000002"/>
+                <odDi:waypoint x="869.5" y="296.6"/>
+                <odDi:odLabel>
+                    <dc:Bounds x="699" y="199" width="82" height="18"/>
+                </odDi:odLabel>
+            </odDi:link>
+            <odDi:link id="Link_Object_2669_to_Object_2839_type_components_di"
+                       boardElement="Link_Object_2669_to_Object_2839_type_components">
+                <odDi:waypoint x="477.7" y="198.60000000000002"/>
+                <odDi:waypoint x="477.7" y="223.60000000000002"/>
+                <odDi:waypoint x="218.5" y="223.60000000000002"/>
+                <odDi:waypoint x="218.5" y="296.6"/>
+                <odDi:odLabel>
+                    <dc:Bounds x="307" y="199" width="82" height="18"/>
+                </odDi:odLabel>
+            </odDi:link>
+            <odDi:link id="Link_Object_2669_to_Object_2840_type_components_di"
+                       boardElement="Link_Object_2669_to_Object_2840_type_components">
+                <odDi:waypoint x="521.9" y="198.60000000000002"/>
+                <odDi:waypoint x="521.9" y="233.60000000000002"/>
+                <odDi:waypoint x="435.5" y="233.60000000000002"/>
+                <odDi:waypoint x="435.5" y="296.6"/>
+                <odDi:odLabel>
+                    <dc:Bounds x="450" y="240" width="82" height="18"/>
+                </odDi:odLabel>
+            </odDi:link>
+            <odDi:odShape id="Object_2669_di" boardElement="Object_2669">
+                <dc:Bounds x="434" y="120" width="221" height="78"/>
+            </odDi:odShape>
+            <odDi:odShape id="Object_2837_di" boardElement="Object_2837">
+                <dc:Bounds x="554" y="297" width="197" height="59"/>
+            </odDi:odShape>
+            <odDi:odShape id="Object_2838_di" boardElement="Object_2838">
+                <dc:Bounds x="771" y="297" width="197" height="59"/>
+            </odDi:odShape>
+            <odDi:odShape id="Object_2839_di" boardElement="Object_2839">
+                <dc:Bounds x="120" y="297" width="197" height="59"/>
+            </odDi:odShape>
+            <odDi:odShape id="Object_2840_di" boardElement="Object_2840">
+                <dc:Bounds x="337" y="297" width="197" height="59"/>
+            </odDi:odShape>
+        </odDi:odPlane>
+    </odDi:odRootBoard>
+</od:definitions>

--- a/starter/e2e/object-diagram.spec.js
+++ b/starter/e2e/object-diagram.spec.js
@@ -1,0 +1,309 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Wait until the diagram has fully rendered (at least one shape on canvas).
+ */
+async function waitForDiagramLoaded(page) {
+  await page.locator(".djs-shape").first().waitFor({ state: "visible" });
+}
+
+/**
+ * Return the data-element-id values of all object shapes on the canvas.
+ */
+async function getObjectShapeIds(page) {
+  return page
+    .locator('.djs-shape[data-element-id^="Object_"]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-element-id")));
+}
+
+/**
+ * Return the data-element-id values of all connection elements on the canvas.
+ */
+async function getConnectionIds(page) {
+  return page
+    .locator('.djs-connection[data-element-id^="Link_"]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-element-id")));
+}
+
+/**
+ * Click a palette entry by its icon CSS class name.
+ */
+async function clickPaletteEntry(page, iconClass) {
+  await page.locator(`.djs-palette .entry.${iconClass}`).click();
+}
+
+/**
+ * Click on the canvas at the given relative position (relative to the #canvas
+ * element's bounding box).
+ */
+async function clickOnCanvas(page, relX, relY) {
+  const canvas = page.locator("#canvas");
+  const box = await canvas.boundingBox();
+  await page.mouse.click(box.x + relX, box.y + relY);
+}
+
+/**
+ * Type text into the currently active direct-editing content.
+ * Uses pressSequentially to properly trigger input events that
+ * diagram-js direct editing expects.
+ */
+async function typeIntoDirectEdit(page, text) {
+  const content = page.locator(
+    ".djs-direct-editing-parent .djs-direct-editing-content",
+  );
+  await content.waitFor({ state: "visible" });
+  // Select all existing text and delete it, then type new text
+  await content.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+  await page.keyboard.type(text);
+}
+
+/**
+ * Complete direct editing by clicking on an empty area of the canvas.
+ * This triggers directEditing.complete() which saves the value.
+ */
+async function finishDirectEdit(page) {
+  // Click on an empty spot on the canvas to complete the edit
+  await clickOnCanvas(page, 50, 50);
+  // Wait for the direct editing overlay to disappear
+  await page
+    .locator(".djs-direct-editing-parent")
+    .waitFor({ state: "hidden", timeout: 3000 })
+    .catch(() => {});
+}
+
+/**
+ * Dismiss the initial direct edit that auto-activates after creating a shape.
+ */
+async function dismissAutoDirectEdit(page) {
+  await page
+    .locator(".djs-direct-editing-parent .djs-direct-editing-content")
+    .waitFor({ state: "visible", timeout: 3000 })
+    .catch(() => {});
+  await finishDirectEdit(page);
+}
+
+/**
+ * Wait for the export debounce (500ms in app.js) to settle so download hrefs
+ * are updated.
+ */
+async function waitForExportUpdate(page) {
+  // The export uses a 500ms debounce; give a bit extra
+  await page.waitForTimeout(800);
+}
+
+/**
+ * Get the decoded href content of a download link.
+ */
+async function getDownloadLinkContent(page, selector) {
+  const href = await page.locator(selector).getAttribute("href");
+  if (!href) return "";
+  const encoded = href.replace(/^data:application\/xml;charset=UTF-8,/, "");
+  return decodeURIComponent(encoded);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("Import / Export", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForDiagramLoaded(page);
+  });
+
+  test("sample board loads on startup", async ({ page }) => {
+    const shapeIds = await getObjectShapeIds(page);
+
+    // The sample board has 5 objects
+    expect(shapeIds).toContain("Object_2669");
+    expect(shapeIds).toContain("Object_2837");
+    expect(shapeIds).toContain("Object_2838");
+    expect(shapeIds).toContain("Object_2839");
+    expect(shapeIds).toContain("Object_2840");
+    expect(shapeIds).toHaveLength(5);
+
+    // And 4 links
+    const connectionIds = await getConnectionIds(page);
+    expect(connectionIds).toHaveLength(4);
+  });
+
+  test("new diagram clears the board", async ({ page }) => {
+    // Click "New diagram" button
+    await page.locator("#js-open-new").click();
+
+    // Wait for shapes to disappear — the empty board has no objects
+    await expect(
+      page.locator('.djs-shape[data-element-id^="Object_"]'),
+    ).toHaveCount(0);
+  });
+
+  test("import XML file", async ({ page }) => {
+    // Start with empty board
+    await page.locator("#js-open-new").click();
+    await expect(
+      page.locator('.djs-shape[data-element-id^="Object_"]'),
+    ).toHaveCount(0);
+
+    // The app creates a hidden file input programmatically.
+    // Trigger the import by setting files on that input.
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(
+      path.join(__dirname, "fixtures", "sampleBoard.xml"),
+    );
+
+    // Wait for the diagram to render
+    await waitForDiagramLoaded(page);
+
+    const shapeIds = await getObjectShapeIds(page);
+    expect(shapeIds).toHaveLength(5);
+    expect(shapeIds).toContain("Object_2669");
+  });
+
+  test("export XML download link contains valid XML", async ({ page }) => {
+    await waitForExportUpdate(page);
+
+    const href = await page.locator("#js-download-board").getAttribute("href");
+    expect(href).toBeTruthy();
+
+    const xml = decodeURIComponent(
+      href.replace("data:application/xml;charset=UTF-8,", ""),
+    );
+
+    // Verify the XML contains expected elements
+    expect(xml).toContain("od:definitions");
+    expect(xml).toContain("od:object");
+    expect(xml).toContain('name="folding_wall_table:Product"');
+    expect(xml).toContain("od:link");
+  });
+
+  test("export SVG download link contains valid SVG", async ({ page }) => {
+    await waitForExportUpdate(page);
+
+    const href = await page.locator("#js-download-svg").getAttribute("href");
+    expect(href).toBeTruthy();
+
+    const content = decodeURIComponent(href.split(",").slice(1).join(","));
+    expect(content).toContain("<svg");
+    expect(content).toContain("</svg>");
+  });
+});
+
+test.describe("Editing", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForDiagramLoaded(page);
+    // Start with a clean canvas for editing tests
+    await page.locator("#js-open-new").click();
+    await expect(
+      page.locator('.djs-shape[data-element-id^="Object_"]'),
+    ).toHaveCount(0);
+  });
+
+  test("create an object via palette", async ({ page }) => {
+    // Click the "Create object" palette entry
+    await clickPaletteEntry(page, "od-icon-object");
+
+    // Click on the canvas to place the object
+    await clickOnCanvas(page, 400, 300);
+
+    // Dismiss the auto-activated direct editing
+    await dismissAutoDirectEdit(page);
+
+    // Verify a new shape appeared
+    const shapes = page.locator(".djs-shape[data-element-id]");
+    const count = await shapes.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test("edit object name", async ({ page }) => {
+    // Create an object
+    await clickPaletteEntry(page, "od-icon-object");
+    await clickOnCanvas(page, 400, 300);
+
+    // Direct editing auto-activates for the name after create
+    await typeIntoDirectEdit(page, "myObj:MyClass");
+    await finishDirectEdit(page);
+
+    // Wait for export debounce to update the XML
+    await waitForExportUpdate(page);
+
+    // Verify the name is in the exported XML
+    const xml = await getDownloadLinkContent(page, "#js-download-board");
+    expect(xml).toContain("myObj:MyClass");
+  });
+
+  test("edit object attributes", async ({ page }) => {
+    // Create an object
+    await clickPaletteEntry(page, "od-icon-object");
+    await clickOnCanvas(page, 400, 300);
+
+    // Dismiss auto direct-edit (which is for the name)
+    await dismissAutoDirectEdit(page);
+
+    // Double-click on the lower part of the shape to edit attributes.
+    // The object's default size is 150x90, title area is top 30px.
+    // We need to double-click below the divider line (y offset > 30 from the
+    // shape's top edge).
+    const shape = page.locator(".djs-shape[data-element-id]").first();
+    const box = await shape.boundingBox();
+
+    // Double-click on the attribute area (below the divider at ~30px from top)
+    await page.mouse.dblclick(box.x + box.width / 2, box.y + 50);
+
+    await typeIntoDirectEdit(page, 'color="red"');
+    await finishDirectEdit(page);
+
+    // Verify the attribute is in the exported XML
+    await waitForExportUpdate(page);
+    const xml = await getDownloadLinkContent(page, "#js-download-board");
+    expect(xml).toContain("color=");
+  });
+
+  test("create two objects and link them", async ({ page }) => {
+    // Create first object
+    await clickPaletteEntry(page, "od-icon-object");
+    await clickOnCanvas(page, 300, 250);
+    await dismissAutoDirectEdit(page);
+
+    // Create second object
+    await clickPaletteEntry(page, "od-icon-object");
+    await clickOnCanvas(page, 600, 250);
+    await dismissAutoDirectEdit(page);
+
+    // Get the two shapes
+    const shapes = page.locator(".djs-shape[data-element-id]");
+    expect(await shapes.count()).toBe(2);
+
+    const firstShape = shapes.first();
+
+    // Click on the first shape to select it — the context pad opens on selection,
+    // not on hover.
+    await firstShape.click();
+
+    // Click the "connect" entry in the context pad (link icon)
+    const connectEntry = page.locator(
+      ".djs-context-pad .entry.bpmn-icon-connection",
+    );
+    await connectEntry.waitFor({ state: "visible", timeout: 5000 });
+    await connectEntry.click();
+
+    // Click on the second shape to complete the connection
+    const secondShape = shapes.nth(1);
+    const secondBox = await secondShape.boundingBox();
+    await page.mouse.click(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height / 2,
+    );
+
+    // Dismiss any direct editing that may activate for the link label
+    await dismissAutoDirectEdit(page);
+
+    // Verify a connection was created
+    const connections = page.locator(".djs-connection[data-element-id]");
+    expect(await connections.count()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/starter/package.json
+++ b/starter/package.json
@@ -12,7 +12,9 @@
     "serve": "serve public",
     "build:github-pages": "rimraf .././docs && webpack --env ghpages",
     "pCheck": "prettier . --check",
-    "pWrite": "prettier . --write"
+    "pWrite": "prettier . --write",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "private": "true",
   "keywords": [
@@ -27,6 +29,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/preset-env": "^7.28.6",
+    "@playwright/test": "^1.58.2",
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^7.1.3",
     "eslint": "^9.39.2",
@@ -34,11 +37,11 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.1",
     "raw-loader": "^4.0.2",
+    "rimraf": "^6.1.2",
     "serve": "^14.2.5",
     "style-loader": "^4.0.0",
     "webpack": "^5.104.1",
-    "webpack-cli": "^6.0.1",
-    "rimraf": "^6.1.2"
+    "webpack-cli": "^6.0.1"
   },
   "dependencies": {
     "inherits": "^2.0.4",

--- a/starter/playwright.config.js
+++ b/starter/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary

- Adds 9 Playwright e2e tests covering import/export and editing functionality for the object diagram starter app
- CI runs in the official Playwright Docker container (`mcr.microsoft.com/playwright:v1.58.2-noble`) — no browser install step needed
- Uploads the Playwright HTML report as a CI artifact on every run

## Test coverage

**Import / Export (5 tests):** sample board loads, new diagram clears board, import XML, export XML, export SVG

**Editing (4 tests):** create object via palette, edit object name, edit object attributes, create two objects and link them via context pad

## Files changed

- `starter/e2e/object-diagram.spec.js` — test suite
- `starter/e2e/fixtures/sampleBoard.xml` — test fixture
- `starter/playwright.config.js` — Playwright config (Chromium only, webServer integration)
- `starter/package.json` — added `@playwright/test` dep and `test:e2e` / `test:e2e:ui` scripts
- `starter/.gitignore` — ignore Playwright output dirs
- `.github/workflows/ci.yml` — new `e2e` job